### PR TITLE
mod_loader: Move game_install_directory on macOS to a better place

### DIFF
--- a/addons/mod_loader/internal/path.gd
+++ b/addons/mod_loader/internal/path.gd
@@ -22,8 +22,8 @@ static func get_game_install_dir() -> String:
 	if OS.get_name() == "macOS":
 		game_install_directory = game_install_directory.get_base_dir().get_base_dir()
 		if game_install_directory.ends_with(".app"):
-			game_install_directory = game_install_directory.get_base_dir()
-
+			game_install_directory = game_install_directory + "/Contents/Resources"
+	print("Game install directory: %s" % game_install_directory)
 	# Fix for running the game through the Godot editor (as the EXE path would be
 	# the editor's own EXE, which won't have any mod ZIPs)
 	# if OS.is_debug_build():


### PR DESCRIPTION
This changes the mods directory to go into Contents/Resources inside the .app